### PR TITLE
Refactor: Capitalize Log and Clock Structs for Exported Access

### DIFF
--- a/oplog/clock.go
+++ b/oplog/clock.go
@@ -1,16 +1,16 @@
 package oplog
 
-type clock struct {
+type Clock struct {
 	id   string
 	time int
 }
 
-func NewClock(id string, time int) *clock {
-	c := clock{id: id, time: time}
+func NewClock(id string, time int) *Clock {
+	c := Clock{id: id, time: time}
 	return &c
 }
 
-func CompareClocks(a clock, b clock) (res int) {
+func CompareClocks(a Clock, b Clock) (res int) {
 	dist := a.time - b.time
 	res = dist
 
@@ -25,6 +25,6 @@ func CompareClocks(a clock, b clock) (res int) {
 	return
 }
 
-func TickClock(c clock) clock {
-	return clock{id: c.id, time: c.time + 1}
+func TickClock(c Clock) Clock {
+	return Clock{id: c.id, time: c.time + 1}
 }

--- a/oplog/log.go
+++ b/oplog/log.go
@@ -1,16 +1,16 @@
 package oplog
 
-type log struct {
+type Log struct {
 	Entries map[string]string
 }
 
-func NewLog() *log {
-	l := log{}
+func NewLog() *Log {
+	l := Log{}
 	l.Entries = make(map[string]string)
 	return &l
 }
 
-func Append(l log, data string) {
+func Append(l Log, data string) {
 	hash := "0"
 	// bytes := []uint8(data)
 	l.Entries[hash] = data


### PR DESCRIPTION
Capitalize log and clock structs to Log and Clock for exportable access.
All relevant function signatures (e.g., NewLog, Append, NewClock, CompareClocks, TickClock) were updated to reflect these changes.
No functional changes were made.