### PR TITLE
Add Identity Support and Digital Signature to Entry Structure

### DIFF
--- a/oplog/entry_test.go
+++ b/oplog/entry_test.go
@@ -6,13 +6,19 @@ import (
 )
 
 func TestNewEntry(t *testing.T) {
+	// Create an identity for the entry
+	identity, err := NewIdentity()
+	if err != nil {
+		t.Fatalf("Failed to create identity: %v", err)
+	}
+
 	// Create an ID and a Clock for the entry
 	id := "test-log-id"
 	clock := NewClock("test-id", 1)
 
-	// Create a new entry with an id, clock, and sample payload
+	// Create a new entry with an identity, id, clock, and sample payload
 	payload := "some entry"
-	e := NewEntry(id, payload, *clock)
+	e := NewEntry(identity, id, payload, *clock)
 
 	// Check if the ID is correctly set
 	if e.ID != id {
@@ -34,6 +40,27 @@ func TestNewEntry(t *testing.T) {
 		t.Errorf("Expected version 2, got %d", e.V)
 	}
 
+	// Check if the key (public key) is correctly set
+	expectedKey := identity.PublicKeyHex()
+	if e.Key != expectedKey {
+		t.Errorf("Expected Key %s, got %s", expectedKey, e.Key)
+	}
+
+	// Check if the identity field matches the identity's identifier
+	if e.Identity != identity.Identity {
+		t.Errorf("Expected Identity %s, got %s", identity.Identity, e.Identity)
+	}
+
+	// Verify that the entry signature is non-empty
+	if e.Signature == "" {
+		t.Error("Expected non-empty signature")
+	}
+
+	// Verify the signature is valid
+	if !VerifyEntrySignature(identity, e) {
+		t.Error("Signature verification failed")
+	}
+
 	// Check if the CBOR bytes are non-empty
 	if e.Bytes.Len() == 0 {
 		t.Error("Expected non-empty Bytes buffer after encoding")
@@ -46,8 +73,26 @@ func TestNewEntry(t *testing.T) {
 }
 
 func TestEncode(t *testing.T) {
-	// Create an entry to test encoding
-	entry := Entry{Payload: "test payload"}
+	// Create an identity for the entry
+	identity, err := NewIdentity()
+	if err != nil {
+		t.Fatalf("Failed to create identity: %v", err)
+	}
+
+	// Create an entry to test encoding with id, payload, clock, key, and identity
+	id := "test-log-id"
+	payload := "test payload"
+	clock := NewClock("test-id", 1)
+	entry := Entry{
+		ID:       id,
+		Payload:  payload,
+		Clock:    *clock,
+		V:        2,
+		Key:      identity.PublicKeyHex(),
+		Identity: identity.Identity,
+	}
+
+	// Encode the entry
 	encodedEntry := Encode(entry)
 
 	// Verify the CBOR-encoded bytes
@@ -61,5 +106,25 @@ func TestEncode(t *testing.T) {
 	// Verify CID generation
 	if encodedEntry.CID.String() == "" {
 		t.Error("Expected a valid CID, but got an empty string")
+	}
+
+	// Check if the ID is correctly encoded
+	if encodedEntry.ID != id {
+		t.Errorf("Expected ID %s, got %s", id, encodedEntry.ID)
+	}
+
+	// Check if the version is correctly encoded as 2
+	if encodedEntry.V != 2 {
+		t.Errorf("Expected version 2, got %d", encodedEntry.V)
+	}
+
+	// Check if the key (public key) is correctly encoded
+	if encodedEntry.Key != identity.PublicKeyHex() {
+		t.Errorf("Expected Key %s, got %s", identity.PublicKeyHex(), encodedEntry.Key)
+	}
+
+	// Check if the identity field matches the identity's identifier
+	if encodedEntry.Identity != identity.Identity {
+		t.Errorf("Expected Identity %s, got %s", identity.Identity, encodedEntry.Identity)
 	}
 }

--- a/oplog/identity.go
+++ b/oplog/identity.go
@@ -1,0 +1,66 @@
+package oplog
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"math/big"
+)
+
+// Identity represents an identity with a public-private key pair
+type Identity struct {
+	PublicKey  ecdsa.PublicKey
+	PrivateKey ecdsa.PrivateKey
+	Identity   string
+}
+
+// NewIdentity generates a new identity with a public-private key pair
+func NewIdentity() (*Identity, error) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey := privateKey.PublicKey
+	identityHash := sha256.Sum256(append(publicKey.X.Bytes(), publicKey.Y.Bytes()...))
+	identity := hex.EncodeToString(identityHash[:])
+
+	return &Identity{
+		PublicKey:  publicKey,
+		PrivateKey: *privateKey,
+		Identity:   identity,
+	}, nil
+}
+
+// Sign signs data with the identity's private key and returns the signature
+func (id *Identity) Sign(data []byte) (string, error) {
+	hash := sha256.Sum256(data)
+	r, s, err := ecdsa.Sign(rand.Reader, &id.PrivateKey, hash[:])
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(r.Bytes()) + hex.EncodeToString(s.Bytes()), nil
+}
+
+// VerifySignature verifies the signature for the given data
+func (id *Identity) VerifySignature(data []byte, signature string) (bool, error) {
+	hash := sha256.Sum256(data)
+	r := new(big.Int)
+	s := new(big.Int)
+
+	sigLen := len(signature) / 2
+	r.SetString(signature[:sigLen], 16)
+	s.SetString(signature[sigLen:], 16)
+
+	valid := ecdsa.Verify(&id.PublicKey, hash[:], r, s)
+	return valid, nil
+}
+
+// PublicKeyHex returns the public key as a hex-encoded string
+func (id *Identity) PublicKeyHex() string {
+	// Concatenate the X and Y coordinates of the public key, and encode to hex
+	pubKeyBytes := append(id.PublicKey.X.Bytes(), id.PublicKey.Y.Bytes()...)
+	return hex.EncodeToString(pubKeyBytes)
+}

--- a/oplog/identity_test.go
+++ b/oplog/identity_test.go
@@ -1,0 +1,24 @@
+package oplog
+
+import "testing"
+
+func TestIdentity(t *testing.T) {
+	// Create a new identity
+	identity, err := NewIdentity()
+	if err != nil {
+		t.Fatalf("Failed to create identity: %v", err)
+	}
+
+	// Sign some data
+	data := []byte("test data")
+	signature, err := identity.Sign(data)
+	if err != nil {
+		t.Fatalf("Failed to sign data: %v", err)
+	}
+
+	// Verify the signature
+	valid, err := identity.VerifySignature(data, signature)
+	if err != nil || !valid {
+		t.Fatalf("Signature verification failed: %v", err)
+	}
+}


### PR DESCRIPTION
Add Identity and Digital Signature Support to Entries

This PR adds identity management and digital signatures to `Entry` for enhanced data integrity and authenticity:

- **Identity Struct**: Generates ECDSA key pair, with `PublicKeyHex()` for hex-encoded public key, and unique `Identity` string.
- **Entry Enhancements**: 
  - Adds `Key`, `Identity`, and `Signature` fields.
  - `NewEntry` now signs entries and includes signature verification with `VerifyEntrySignature`.
- **IPLD Schema Update**: Adds support for `key`, `identity`, and `signature` fields.
- **Tests**: Updates to validate `Key`, `Identity`, and `Signature`, and check signature verification.

This prepares `Entry` for secure and verifiable identity management.
