### PR TITLE
Integrate KeyStore for Key Management and Signature Verification

### DIFF
--- a/identities/identities.go
+++ b/identities/identities.go
@@ -93,7 +93,7 @@ func (ids *Identities) Verify(signature string, identity *identitytypes.Identity
 	}
 
 	// Use VerifyMessage from KeyStore to verify the signature
-	verified, err := keystore.VerifyMessage(pubKey, data, signature)
+	verified, err := ids.keystore.VerifyMessage(pubKey, data, signature)
 	return err == nil && verified
 }
 

--- a/identities/identities.go
+++ b/identities/identities.go
@@ -39,6 +39,16 @@ func NewIdentities(providerType string) (*Identities, error) {
 	}, nil
 }
 
+// ClearAll clears all keys from the KeyStore
+func (ids *Identities) ClearAll() {
+	ids.keystore.Clear()
+}
+
+// AddManualKey allows adding an externally generated key.
+func (ids *Identities) AddManualKey(id string, privateKey *ecdsa.PrivateKey) error {
+	return ids.keystore.AddKey(id, privateKey)
+}
+
 // CreateIdentity generates a new identity using the selected provider.
 func (ids *Identities) CreateIdentity(id string) (*identitytypes.Identity, error) {
 	identity, err := ids.provider.CreateIdentity(id)

--- a/identities/identities_test.go
+++ b/identities/identities_test.go
@@ -1,14 +1,12 @@
 package identities
 
 import (
-	"orbitdb/go-orbitdb/identities/providers"
 	"testing"
 )
 
 // Helper function to initialize Identities with a public key provider
 func setupIdentities() (*Identities, error) {
 	// Register the PublicKeyProvider
-	RegisterProvider(providers.NewPublicKeyProvider())
 	return NewIdentities("publickey")
 }
 
@@ -82,12 +80,13 @@ func TestSignAndVerify(t *testing.T) {
 	}
 
 	data := []byte("test data")
-	signature, err := identities.Sign(identity, data)
+	// Pass identity ID directly to Sign instead of the Identity struct
+	signature, err := identities.Sign(identity.ID, data)
 	if err != nil {
 		t.Fatalf("Expected no error signing data, got %v", err)
 	}
 
-	// Verify the signature
+	// Verify the signature with the updated Verify method
 	if !identities.Verify(signature, identity, data) {
 		t.Fatal("Expected valid signature verification to succeed")
 	}

--- a/identities/identitytypes/identity.go
+++ b/identities/identitytypes/identity.go
@@ -2,10 +2,6 @@ package identitytypes
 
 import (
 	"bytes"
-	"crypto/ecdsa"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"github.com/ipfs/go-cid"
@@ -14,14 +10,12 @@ import (
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/multiformats/go-multibase"
 	mh "github.com/multiformats/go-multihash"
-	"math/big"
 )
 
 // Identity represents a basic identity structure.
 type Identity struct {
 	ID         string            // Unique ID for the identity
 	PublicKey  string            // Hex representation of the public key
-	PrivateKey *ecdsa.PrivateKey // ECDSA private key for signing
 	Hash       string            // Hash of the identity (ID + PublicKey)
 	Signatures map[string]string // Signatures for id and publicKey
 	Bytes      []byte            // Encoded byte representation of the identity
@@ -34,37 +28,6 @@ type EncodedIdentity struct {
 	Bytes    []byte
 	CID      cid.Cid
 	Hash     string
-}
-
-// Sign generates a signature for the provided data using the private key.
-func (i *Identity) Sign(data []byte) (string, error) {
-	// Hash the data
-	hashedData := sha256.Sum256(data)
-	r, s, err := ecdsa.Sign(rand.Reader, i.PrivateKey, hashedData[:])
-	if err != nil {
-		return "", err
-	}
-
-	// Concatenate r and s values and encode as hex
-	signature := append(r.Bytes(), s.Bytes()...)
-	return hex.EncodeToString(signature), nil
-}
-
-// Verify checks if the provided signature is valid for the data.
-func (i *Identity) Verify(signatureHex string, data []byte) bool {
-	sigBytes, err := hex.DecodeString(signatureHex)
-	if err != nil || len(sigBytes) < 64 {
-		return false
-	}
-
-	r := new(big.Int).SetBytes(sigBytes[:len(sigBytes)/2])
-	s := new(big.Int).SetBytes(sigBytes[len(sigBytes)/2:])
-
-	// Hash the data
-	hashedData := sha256.Sum256(data)
-
-	// Verify the signature
-	return ecdsa.Verify(&i.PrivateKey.PublicKey, hashedData[:], r, s)
 }
 
 // IsIdentity Checks if an identity has all required fields populated.

--- a/identities/identitytypes/identity_test.go
+++ b/identities/identitytypes/identity_test.go
@@ -16,15 +16,14 @@ func createTestIdentity(id string, identityType string) (*Identity, error) {
 		return nil, err
 	}
 
-	// Encode the public key
+	// Encode the public key as a hex string
 	publicKeyBytes := append(privateKey.PublicKey.X.Bytes(), privateKey.PublicKey.Y.Bytes()...)
 	publicKeyHex := hex.EncodeToString(publicKeyBytes)
 
-	// Create the Identity object
+	// Create the Identity object without PrivateKey
 	identity := &Identity{
-		ID:         id,
-		PublicKey:  publicKeyHex,
-		PrivateKey: privateKey,
+		ID:        id,
+		PublicKey: publicKeyHex,
 		Signatures: map[string]string{
 			"id":        "test-id-signature",
 			"publicKey": "test-publicKey-signature",
@@ -43,31 +42,7 @@ func createTestIdentity(id string, identityType string) (*Identity, error) {
 	return identity, nil
 }
 
-func TestSignAndVerify(t *testing.T) {
-	identity, err := createTestIdentity("test-id", "test-type")
-	if err != nil {
-		t.Fatalf("Failed to create test identity: %v", err)
-	}
-
-	data := []byte("test-data")
-
-	// Test Sign
-	signature, err := identity.Sign(data)
-	if err != nil {
-		t.Fatalf("Failed to sign data: %v", err)
-	}
-
-	// Test Verify
-	if !identity.Verify(signature, data) {
-		t.Fatal("Expected valid signature verification to succeed")
-	}
-
-	// Test with altered data
-	if identity.Verify(signature, []byte("tampered-data")) {
-		t.Fatal("Expected verification to fail with altered data")
-	}
-}
-
+// TestIsIdentity checks if an identity has all required fields populated.
 func TestIsIdentity(t *testing.T) {
 	identity, err := createTestIdentity("test-id", "test-type")
 	if err != nil {
@@ -85,6 +60,7 @@ func TestIsIdentity(t *testing.T) {
 	}
 }
 
+// TestIsEqual checks if two identities are identical based on key properties.
 func TestIsEqual(t *testing.T) {
 	identityA, err := createTestIdentity("test-id", "test-type")
 	if err != nil {
@@ -113,6 +89,7 @@ func TestIsEqual(t *testing.T) {
 	}
 }
 
+// TestEncodeDecodeIdentity verifies encoding and decoding of an identity.
 func TestEncodeDecodeIdentity(t *testing.T) {
 	identity, err := createTestIdentity("test-id", "test-type")
 	if err != nil {

--- a/identities/providers/public_key_provider.go
+++ b/identities/providers/public_key_provider.go
@@ -97,14 +97,14 @@ func (p *PublicKeyProvider) VerifyIdentity(identity *identitytypes.Identity) (bo
 		Y:     new(big.Int).SetBytes(publicKeyBytes[len(publicKeyBytes)/2:]),
 	}
 
-	// Verify ID signature
-	idVerified, err := keystore.VerifyMessage(pubKey, []byte(identity.ID), identity.Signatures["id"])
+	// Verify the ID signature using the KeyStore's VerifyMessage method
+	idVerified, err := p.keystore.VerifyMessage(pubKey, []byte(identity.ID), identity.Signatures["id"])
 	if err != nil || !idVerified {
 		return false, errors.New("invalid ID signature")
 	}
 
-	// Verify public key signature
-	publicKeyVerified, err := keystore.VerifyMessage(pubKey, []byte(identity.PublicKey), identity.Signatures["publicKey"])
+	// Verify the public key signature using the KeyStore's VerifyMessage method
+	publicKeyVerified, err := p.keystore.VerifyMessage(pubKey, []byte(identity.PublicKey), identity.Signatures["publicKey"])
 	if err != nil || !publicKeyVerified {
 		return false, errors.New("invalid public key signature")
 	}

--- a/identities/providers/public_key_provider.go
+++ b/identities/providers/public_key_provider.go
@@ -96,38 +96,3 @@ func (p *PublicKeyProvider) VerifyIdentity(identity *identitytypes.Identity) (bo
 
 	return true, nil
 }
-
-// GetId retrieves or generates an ID based on the identity's public key.
-func (p *PublicKeyProvider) GetId(id string) (string, error) {
-	privateKey := createHardcodedKeyPair() // Replace with keystore logic in the future
-	publicKey := append(privateKey.PublicKey.X.Bytes(), privateKey.PublicKey.Y.Bytes()...)
-	return hex.EncodeToString(publicKey), nil
-}
-
-// Sign signs data using the identity's private key.
-func (p *PublicKeyProvider) Sign(data string, identity *identitytypes.Identity) (string, error) {
-	return identity.Sign([]byte(data))
-}
-
-// Verify verifies the identity signature.
-func (p *PublicKeyProvider) Verify(identity *identitytypes.Identity, signature string, data []byte) bool {
-	return identity.Verify(signature, data)
-}
-
-// NewPublicKeyProvider creates a new instance of PublicKeyProvider.
-func NewPublicKeyProvider() *PublicKeyProvider {
-	return &PublicKeyProvider{}
-}
-
-func signData(privateKey *ecdsa.PrivateKey, data []byte) (string, error) {
-	// Hash the data to create a deterministic signature
-	hash := sha256.Sum256(data)
-
-	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash[:])
-	if err != nil {
-		return "", err
-	}
-
-	// Encode the signature as a hex string
-	return hex.EncodeToString(r.Bytes()) + hex.EncodeToString(s.Bytes()), nil
-}

--- a/identities/providers/public_key_provider.go
+++ b/identities/providers/public_key_provider.go
@@ -3,8 +3,6 @@ package providers
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"math/big"
@@ -110,8 +108,6 @@ func (p *PublicKeyProvider) VerifyIdentity(identity *identitytypes.Identity) (bo
 	if err != nil || !publicKeyVerified {
 		return false, errors.New("invalid public key signature")
 	}
-
-	// Additional validation can be added here if needed
 
 	return true, nil
 }

--- a/identities/providers/public_key_provider.go
+++ b/identities/providers/public_key_provider.go
@@ -9,12 +9,19 @@ import (
 	"errors"
 	"math/big"
 	"orbitdb/go-orbitdb/identities/identitytypes"
+	"orbitdb/go-orbitdb/keystore"
 )
 
-// PublicKeyProvider is a simple provider using public key-based identities.
-type PublicKeyProvider struct{}
+// PublicKeyProvider is a provider using public key-based identities and a KeyStore.
+type PublicKeyProvider struct {
+	keystore *keystore.KeyStore
+}
 
-// Type returns the provider type.
+// NewPublicKeyProvider creates a new PublicKeyProvider with a KeyStore.
+func NewPublicKeyProvider(ks *keystore.KeyStore) *PublicKeyProvider {
+	return &PublicKeyProvider{keystore: ks}
+}
+
 func (p *PublicKeyProvider) Type() string {
 	return "publickey"
 }

--- a/identities/providers/public_key_provider.go
+++ b/identities/providers/public_key_provider.go
@@ -26,18 +26,7 @@ func (p *PublicKeyProvider) Type() string {
 	return "publickey"
 }
 
-// createHardcodedKeyPair creates a fixed ECDSA private key for hardcoded testing.
-func createHardcodedKeyPair() *ecdsa.PrivateKey {
-	privateKey := new(ecdsa.PrivateKey)
-	privateKey.PublicKey.Curve = elliptic.P256()
-
-	privateKey.D, _ = new(big.Int).SetString("5e5d9e0a44685aee2282a44d2d3e9a1b", 16)
-	privateKey.PublicKey.X, privateKey.PublicKey.Y = privateKey.PublicKey.Curve.ScalarBaseMult(privateKey.D.Bytes())
-
-	return privateKey
-}
-
-// CreateIdentity generates a new Identity instance using the hardcoded ECDSA private key.
+// CreateIdentity generates a new identity, signing the ID and public key.
 func (p *PublicKeyProvider) CreateIdentity(id string) (*identitytypes.Identity, error) {
 	privateKey := createHardcodedKeyPair()
 

--- a/identities/providers/public_key_provider_test.go
+++ b/identities/providers/public_key_provider_test.go
@@ -54,12 +54,12 @@ func TestCreateIdentity(t *testing.T) {
 		Y:     new(big.Int).SetBytes(publicKeyBytes[len(publicKeyBytes)/2:]),
 	}
 
-	idVerified, err := keystore.VerifyMessage(pubKey, []byte(identity.ID), identity.Signatures["id"])
+	idVerified, err := ks.VerifyMessage(pubKey, []byte(identity.ID), identity.Signatures["id"])
 	if err != nil || !idVerified {
 		t.Fatal("Expected ID signature to be valid")
 	}
 
-	publicKeyVerified, err := keystore.VerifyMessage(pubKey, []byte(identity.PublicKey), identity.Signatures["publicKey"])
+	publicKeyVerified, err := ks.VerifyMessage(pubKey, []byte(identity.PublicKey), identity.Signatures["publicKey"])
 	if err != nil || !publicKeyVerified {
 		t.Fatal("Expected public key signature to be valid")
 	}

--- a/keystore/key-store.go
+++ b/keystore/key-store.go
@@ -102,7 +102,7 @@ func (ks *KeyStore) SignMessage(id string, data []byte) (string, error) {
 }
 
 // VerifyMessage verifies the signature against the data using the public key.
-func VerifyMessage(publicKey ecdsa.PublicKey, data []byte, signature string) (bool, error) {
+func (ks *KeyStore) VerifyMessage(publicKey ecdsa.PublicKey, data []byte, signature string) (bool, error) {
 	sigBytes, err := hex.DecodeString(signature)
 	if err != nil || len(sigBytes) < 64 {
 		return false, err

--- a/keystore/key-store.go
+++ b/keystore/key-store.go
@@ -1,0 +1,116 @@
+package keystore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"sync"
+)
+
+// KeyStore provides a simple key management system.
+type KeyStore struct {
+	storage map[string]*ecdsa.PrivateKey
+	mu      sync.Mutex
+}
+
+// NewKeyStore initializes a new in-memory KeyStore.
+func NewKeyStore() *KeyStore {
+	return &KeyStore{
+		storage: make(map[string]*ecdsa.PrivateKey),
+	}
+}
+
+// CreateKey generates a new ECDSA key pair and stores it under the given ID.
+func (ks *KeyStore) CreateKey(id string) (*ecdsa.PrivateKey, error) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	if _, exists := ks.storage[id]; exists {
+		return nil, errors.New("key already exists for this ID")
+	}
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	ks.storage[id] = privateKey
+	return privateKey, nil
+}
+
+// HasKey checks if a key exists for a given ID.
+func (ks *KeyStore) HasKey(id string) bool {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	_, exists := ks.storage[id]
+	return exists
+}
+
+// AddKey Adds a private key directly to the keystore (e.g., for imported keys).
+func (ks *KeyStore) AddKey(id string, privateKey *ecdsa.PrivateKey) error {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	if _, exists := ks.storage[id]; exists {
+		return errors.New("key already exists for this ID")
+	}
+	ks.storage[id] = privateKey
+	return nil
+}
+
+// Clear removes all keys from the KeyStore.
+func (ks *KeyStore) Clear() {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	ks.storage = make(map[string]*ecdsa.PrivateKey)
+}
+
+// GetKey retrieves a private key by ID from storage.
+func (ks *KeyStore) GetKey(id string) (*ecdsa.PrivateKey, error) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	privateKey, exists := ks.storage[id]
+	if !exists {
+		return nil, errors.New("key not found")
+	}
+
+	return privateKey, nil
+}
+
+// SignMessage signs data using the private key associated with the given ID.
+func (ks *KeyStore) SignMessage(id string, data []byte) (string, error) {
+	privateKey, err := ks.GetKey(id)
+	if err != nil {
+		return "", err
+	}
+
+	hash := sha256.Sum256(data)
+	r, s, err := ecdsa.Sign(rand.Reader, privateKey, hash[:])
+	if err != nil {
+		return "", err
+	}
+
+	signature := append(r.Bytes(), s.Bytes()...)
+	return hex.EncodeToString(signature), nil
+}
+
+// VerifyMessage verifies the signature against the data using the public key.
+func VerifyMessage(publicKey ecdsa.PublicKey, data []byte, signature string) (bool, error) {
+	sigBytes, err := hex.DecodeString(signature)
+	if err != nil || len(sigBytes) < 64 {
+		return false, err
+	}
+
+	r := new(big.Int).SetBytes(sigBytes[:len(sigBytes)/2])
+	s := new(big.Int).SetBytes(sigBytes[len(sigBytes)/2:])
+
+	hash := sha256.Sum256(data)
+	return ecdsa.Verify(&publicKey, hash[:], r, s), nil
+}

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -155,7 +155,7 @@ func TestVerifyMessage(t *testing.T) {
 	}
 
 	// Verify the message using the public key
-	valid, err := VerifyMessage(privateKey.PublicKey, data, signature)
+	valid, err := ks.VerifyMessage(privateKey.PublicKey, data, signature)
 	if err != nil {
 		t.Fatalf("Expected no error verifying message, got %v", err)
 	}
@@ -164,7 +164,7 @@ func TestVerifyMessage(t *testing.T) {
 	}
 
 	// Attempt verification with altered data
-	valid, err = VerifyMessage(privateKey.PublicKey, []byte("tampered-data"), signature)
+	valid, err = ks.VerifyMessage(privateKey.PublicKey, []byte("tampered-data"), signature)
 	if err != nil {
 		t.Fatalf("Expected no error with verification attempt, got %v", err)
 	}
@@ -174,7 +174,7 @@ func TestVerifyMessage(t *testing.T) {
 
 	// Attempt verification with an invalid signature format
 	invalidSig := "invalid-signature"
-	valid, err = VerifyMessage(privateKey.PublicKey, data, invalidSig)
+	valid, err = ks.VerifyMessage(privateKey.PublicKey, data, invalidSig)
 	if err == nil {
 		t.Fatal("Expected error with invalid signature format, got nil")
 	}

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -1,0 +1,184 @@
+package keystore
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+)
+
+func TestNewKeyStore(t *testing.T) {
+	ks := NewKeyStore()
+	if ks == nil {
+		t.Fatal("Expected KeyStore instance, got nil")
+	}
+}
+
+func TestCreateKey(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+
+	_, err := ks.CreateKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Attempt to create a key with the same ID again
+	_, err = ks.CreateKey(id)
+	if err == nil {
+		t.Fatal("Expected error when creating duplicate key, got nil")
+	}
+}
+
+func TestHasKey(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+
+	if ks.HasKey(id) {
+		t.Fatal("Expected HasKey to return false for nonexistent key")
+	}
+
+	_, err := ks.CreateKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !ks.HasKey(id) {
+		t.Fatal("Expected HasKey to return true for existing key")
+	}
+}
+
+func TestAddKey(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+
+	// Generate a new ECDSA key pair
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Error generating test private key: %v", err)
+	}
+
+	// Add the key to the KeyStore
+	err = ks.AddKey(id, privateKey)
+	if err != nil {
+		t.Fatalf("Expected no error adding key, got %v", err)
+	}
+
+	// Attempt to add the same key again
+	err = ks.AddKey(id, privateKey)
+	if err == nil {
+		t.Fatal("Expected error when adding duplicate key, got nil")
+	}
+}
+
+func TestClear(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+
+	_, err := ks.CreateKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Clear all keys
+	ks.Clear()
+
+	if ks.HasKey(id) {
+		t.Fatal("Expected HasKey to return false after clearing KeyStore")
+	}
+}
+
+func TestGetKey(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+
+	// Create a new key
+	privateKey, err := ks.CreateKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Retrieve the key
+	retrievedKey, err := ks.GetKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if retrievedKey != privateKey {
+		t.Fatal("Expected retrieved key to match the original key")
+	}
+
+	// Attempt to retrieve a non-existent key
+	_, err = ks.GetKey("nonexistent-id")
+	if err == nil {
+		t.Fatal("Expected error for non-existent key, got nil")
+	}
+}
+
+func TestSignMessage(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+	data := []byte("test-data")
+
+	// Create a new key and sign a message
+	_, err := ks.CreateKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	_, err = ks.SignMessage(id, data)
+	if err != nil {
+		t.Fatalf("Expected no error signing message, got %v", err)
+	}
+
+	// Attempt to sign with a non-existent key
+	_, err = ks.SignMessage("nonexistent-id", data)
+	if err == nil {
+		t.Fatal("Expected error when signing with non-existent key, got nil")
+	}
+}
+
+func TestVerifyMessage(t *testing.T) {
+	ks := NewKeyStore()
+	id := "test-id"
+	data := []byte("test-data")
+
+	// Create a new key and sign a message
+	privateKey, err := ks.CreateKey(id)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	signature, err := ks.SignMessage(id, data)
+	if err != nil {
+		t.Fatalf("Expected no error signing message, got %v", err)
+	}
+
+	// Verify the message using the public key
+	valid, err := VerifyMessage(privateKey.PublicKey, data, signature)
+	if err != nil {
+		t.Fatalf("Expected no error verifying message, got %v", err)
+	}
+	if !valid {
+		t.Fatal("Expected signature to be valid")
+	}
+
+	// Attempt verification with altered data
+	valid, err = VerifyMessage(privateKey.PublicKey, []byte("tampered-data"), signature)
+	if err != nil {
+		t.Fatalf("Expected no error with verification attempt, got %v", err)
+	}
+	if valid {
+		t.Fatal("Expected signature verification to fail with altered data")
+	}
+
+	// Attempt verification with an invalid signature format
+	invalidSig := "invalid-signature"
+	valid, err = VerifyMessage(privateKey.PublicKey, data, invalidSig)
+	if err == nil {
+		t.Fatal("Expected error with invalid signature format, got nil")
+	}
+	if valid {
+		t.Fatal("Expected invalid signature verification to fail")
+	}
+}

--- a/oplog/entry.go
+++ b/oplog/entry.go
@@ -94,8 +94,7 @@ func NewEntry(ks *keystore.KeyStore, identity *identitytypes.Identity, id string
 }
 
 // VerifyEntrySignature verifies the signature on an entry using KeyStore.
-func VerifyEntrySignature(identity *identitytypes.Identity, entry EncodedEntry) bool {
-
+func VerifyEntrySignature(ks *keystore.KeyStore, identity *identitytypes.Identity, entry EncodedEntry) bool {
 	// Recreate the entry data without Signature, Key, and Identity fields
 	entryData := Entry{
 		ID:      entry.ID,
@@ -122,11 +121,9 @@ func VerifyEntrySignature(identity *identitytypes.Identity, entry EncodedEntry) 
 		Y:     new(big.Int).SetBytes(publicKeyBytes[len(publicKeyBytes)/2:]),
 	}
 
-	verified, err := keystore.VerifyMessage(pubKey, reconstructedEncodedEntry.Bytes, entry.Signature)
-	if err != nil {
-		return false
-	}
-	return verified
+	// Use the KeyStore instance to verify the signature
+	verified, err := ks.VerifyMessage(pubKey, reconstructedEncodedEntry.Bytes, entry.Signature)
+	return err == nil && verified
 }
 
 // IsEntry checks if an object is a valid entry

--- a/oplog/entry_test.go
+++ b/oplog/entry_test.go
@@ -46,14 +46,14 @@ func TestVerifyEntrySignature(t *testing.T) {
 	clock := Clock{ID: "test-clock", Time: 1}
 	entry := NewEntry(ks, identity, "entry-id", "payload-data", clock, nil, nil)
 
-	isValid := VerifyEntrySignature(identity, entry)
+	isValid := VerifyEntrySignature(ks, identity, entry)
 	if !isValid {
 		t.Error("Expected signature to be valid, but verification failed")
 	}
 
 	// Modify the payload and check that the signature verification fails
 	entry.Payload = "tampered-payload"
-	isValid = VerifyEntrySignature(identity, entry)
+	isValid = VerifyEntrySignature(ks, identity, entry)
 	if isValid {
 		t.Error("Expected signature verification to fail for tampered entry, but it succeeded")
 	}

--- a/oplog/entry_test.go
+++ b/oplog/entry_test.go
@@ -2,27 +2,27 @@ package oplog
 
 import (
 	"bytes"
+	"orbitdb/go-orbitdb/keystore"
 	"testing"
 
 	"orbitdb/go-orbitdb/identities/identitytypes"
 	"orbitdb/go-orbitdb/identities/providers"
 )
 
-func generateTestIdentity(t *testing.T) *identitytypes.Identity {
-
-	provider := providers.NewPublicKeyProvider()
+func setupTestKeyStoreAndIdentity(t *testing.T) (*keystore.KeyStore, *identitytypes.Identity) {
+	ks := keystore.NewKeyStore()
+	provider := providers.NewPublicKeyProvider(ks)
 	identity, err := provider.CreateIdentity("test-id")
 	if err != nil {
 		t.Fatalf("Failed to create identity: %v", err)
 	}
-
-	return identity
+	return ks, identity
 }
 
 func TestNewEntry(t *testing.T) {
-	identity := generateTestIdentity(t)
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 	clock := Clock{ID: "test-clock", Time: 1}
-	entry := NewEntry(identity, "entry-id", "payload-data", clock, nil, nil)
+	entry := NewEntry(ks, identity, "entry-id", "payload-data", clock, nil, nil)
 
 	if entry.ID != "entry-id" {
 		t.Errorf("Expected entry ID to be 'entry-id', got '%s'", entry.ID)
@@ -42,9 +42,9 @@ func TestNewEntry(t *testing.T) {
 }
 
 func TestVerifyEntrySignature(t *testing.T) {
-	identity := generateTestIdentity(t)
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 	clock := Clock{ID: "test-clock", Time: 1}
-	entry := NewEntry(identity, "entry-id", "payload-data", clock, nil, nil)
+	entry := NewEntry(ks, identity, "entry-id", "payload-data", clock, nil, nil)
 
 	isValid := VerifyEntrySignature(identity, entry)
 	if !isValid {
@@ -77,11 +77,11 @@ func TestIsEntry(t *testing.T) {
 }
 
 func TestIsEqual(t *testing.T) {
-	identity := generateTestIdentity(t)
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 	clock := Clock{ID: "test-clock", Time: 1}
 
-	entry1 := NewEntry(identity, "entry-id", "payload-data", clock, nil, nil)
-	entry2 := NewEntry(identity, "entry-id", "payload-data", clock, nil, nil)
+	entry1 := NewEntry(ks, identity, "entry-id", "payload-data", clock, nil, nil)
+	entry2 := NewEntry(ks, identity, "entry-id", "payload-data", clock, nil, nil)
 
 	// Both entries have identical content, so they should have the same serialized bytes
 	if !IsEqual(entry1, entry2) {
@@ -89,7 +89,7 @@ func TestIsEqual(t *testing.T) {
 	}
 
 	// Create an entry with different content and check equality
-	entry3 := NewEntry(identity, "entry-id", "different-payload", clock, nil, nil)
+	entry3 := NewEntry(ks, identity, "entry-id", "different-payload", clock, nil, nil)
 	if IsEqual(entry1, entry3) {
 		t.Error("Expected entries with different content to not be equal")
 	}


### PR DESCRIPTION
This PR refactors the project to use a centralized `KeyStore` for all key management and signature verification, enhancing modularity, maintainability, and testability.

#### Key Changes:

1. **KeyStore Integration**:
   - Added `KeyStore` for managing ECDSA keys, signing, and verification.
   - Integrated `KeyStore` in `Identities`, `PublicKeyProvider`, and `Entry` for consistent key handling.

2. **Refactored `Identities` and `PublicKeyProvider`**:
   - Replaced individual key handling with `KeyStore` calls in `Sign`, `Verify`, `CreateIdentity`, and `VerifyIdentity`.
   - Removed redundant cryptographic functions from `PublicKeyProvider`.

3. **Updated `Entry` Signature Handling**:
   - Modified `NewEntry` and `VerifyEntrySignature` to use `KeyStore` for signing and verifying, removing direct key access.

4. **Test Updates**:
   - Added tests for `KeyStore` functionality.
   - Refactored all relevant tests (`identities_test.go`, `public_key_provider_test.go`, etc.) to align with `KeyStore` integration.