### PR TITLE
Refactor Log and Entry Modules 

### DIFF
--- a/keystore/key-store.go
+++ b/keystore/key-store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"orbitdb/go-orbitdb/storage"
 	"sync"
@@ -180,4 +181,24 @@ func DeserializePrivateKey(data []byte) (*ecdsa.PrivateKey, error) {
 		},
 		D: d,
 	}, nil
+}
+
+func ReconstructPublicKeyFromHex(pubKeyHex string) (*ecdsa.PublicKey, error) {
+	pubKeyBytes, err := hex.DecodeString(pubKeyHex)
+	if err != nil {
+		return nil, err
+	}
+	if len(pubKeyBytes) != 64 {
+		return nil, fmt.Errorf("invalid public key length: %d", len(pubKeyBytes))
+	}
+	xBytes := pubKeyBytes[:32]
+	yBytes := pubKeyBytes[32:]
+	x := new(big.Int).SetBytes(xBytes)
+	y := new(big.Int).SetBytes(yBytes)
+	pubKey := &ecdsa.PublicKey{
+		Curve: elliptic.P256(),
+		X:     x,
+		Y:     y,
+	}
+	return pubKey, nil
 }

--- a/keystore/key-store.go
+++ b/keystore/key-store.go
@@ -128,8 +128,8 @@ func (ks *KeyStore) SignMessage(id string, data []byte) (string, error) {
 }
 
 // VerifyMessage verifies the signature against the data using the public key.
-func (ks *KeyStore) VerifyMessage(publicKey ecdsa.PublicKey, data []byte, signature string) (bool, error) {
-	sigBytes, err := hex.DecodeString(signature)
+func (ks *KeyStore) VerifyMessage(publicKey ecdsa.PublicKey, data []byte, signatureHex string) (bool, error) {
+	sigBytes, err := hex.DecodeString(signatureHex)
 	if err != nil || len(sigBytes) < 64 {
 		return false, err
 	}

--- a/oplog/entry.go
+++ b/oplog/entry.go
@@ -86,12 +86,7 @@ func NewEntry(ks *keystore.KeyStore, identity *identitytypes.Identity, id string
 	entry.Identity = identity.Hash
 	entry.Signature = signature
 
-	return EncodedEntry{
-		Entry: entry,
-		Bytes: encodedEntry.Bytes,
-		CID:   encodedEntry.CID,
-		Hash:  encodedEntry.Hash,
-	}
+	return Encode(entry)
 }
 
 // VerifyEntrySignature verifies the signature on an entry using KeyStore.

--- a/oplog/entry.go
+++ b/oplog/entry.go
@@ -127,9 +127,31 @@ func IsEntry(entry Entry) bool {
 	return entry.ID != "" && entry.Payload != "" && entry.Clock.ID != "" && entry.Clock.Time > 0
 }
 
-// IsEqual checks if two entries are equal based on their hash values
-func IsEqual(a EncodedEntry, b EncodedEntry) bool {
-	return a.Hash == b.Hash
+// IsEqual checks if two entries are equal. Exclude Signature, Hash, and Bytes from the comparison since they can differ even if the entries have the same content.
+// The reason is The ECDSA algorithm uses a random value (k) during the signing process to ensure that each signature is unique and secure.
+// Even if the same message is signed multiple times with the same private key, the signatures will be different due to this randomness.
+func IsEqual(entry1 EncodedEntry, entry2 EncodedEntry) bool {
+	return entry1.Entry.ID == entry2.Entry.ID &&
+		entry1.Entry.Payload == entry2.Entry.Payload &&
+		EqualStringSlices(entry1.Entry.Next, entry2.Entry.Next) &&
+		EqualStringSlices(entry1.Entry.Refs, entry2.Entry.Refs) &&
+		entry1.Entry.Clock.ID == entry2.Entry.Clock.ID &&
+		entry1.Entry.Clock.Time == entry2.Entry.Clock.Time &&
+		entry1.Entry.V == entry2.Entry.V &&
+		entry1.Entry.Key == entry2.Entry.Key &&
+		entry1.Entry.Identity == entry2.Entry.Identity
+}
+
+func EqualStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Encode encodes the entry into CBOR and returns an EncodedEntry

--- a/oplog/entry_test.go
+++ b/oplog/entry_test.go
@@ -52,14 +52,14 @@ func TestVerifyEntrySignature(t *testing.T) {
 	clock := Clock{ID: "test-clock", Time: 1}
 	entry := NewEntry(ks, identity, "entry-id", "payload-data", clock, nil, nil)
 
-	isValid := VerifyEntrySignature(ks, identity, entry)
+	isValid := VerifyEntrySignature(ks, entry)
 	if !isValid {
 		t.Error("Expected signature to be valid, but verification failed")
 	}
 
 	// Modify the payload and check that the signature verification fails
-	entry.Payload = "tampered-payload"
-	isValid = VerifyEntrySignature(ks, identity, entry)
+	entry.Entry.Payload = "tampered-payload"
+	isValid = VerifyEntrySignature(ks, entry)
 	if isValid {
 		t.Error("Expected signature verification to fail for tampered entry, but it succeeded")
 	}

--- a/oplog/log.go
+++ b/oplog/log.go
@@ -14,7 +14,7 @@ import (
 // Log represents an append-only log
 type Log struct {
 	id       string
-	identity identitytypes.Identity
+	identity *identitytypes.Identity
 	clock    Clock
 	head     *EncodedEntry
 	entries  storage.Storage
@@ -51,7 +51,7 @@ func NewLog(id string, identity *identitytypes.Identity, entryStorage storage.St
 
 	return &Log{
 		id:       id,
-		identity: *identity,
+		identity: identity,
 		clock:    NewClock(identity.ID, 0),
 		entries:  entryStorage,
 		keystore: keyStore,
@@ -74,11 +74,7 @@ func (l *Log) Append(payload string) (*EncodedEntry, error) {
 		next = []string{l.head.Hash}
 	}
 
-	identity := &identitytypes.Identity{
-		PublicKey: l.identity.PublicKey,
-		ID:        l.identity.ID,
-	}
-	entry := NewEntry(l.keystore, identity, l.id, payload, l.clock, next, nil)
+	entry := NewEntry(l.keystore, l.identity, l.id, payload, l.clock, next, nil)
 
 	if err := l.entries.Put(entry.Hash, entry.Bytes); err != nil {
 		return nil, fmt.Errorf("failed to store entry: %w", err)

--- a/oplog/log.go
+++ b/oplog/log.go
@@ -99,7 +99,7 @@ func (l *Log) Get(hash string) (*EncodedEntry, error) {
 		return nil, fmt.Errorf("failed to decode entry for hash %s: %w", hash, err)
 	}
 
-	if !VerifyEntrySignature(l.keystore, l.identity, entry) {
+	if !VerifyEntrySignature(l.keystore, entry) {
 		return nil, fmt.Errorf("invalid signature for entry %s", hash)
 	}
 
@@ -124,7 +124,7 @@ func (l *Log) Values() ([]EncodedEntry, error) {
 			continue
 		}
 
-		if !VerifyEntrySignature(l.keystore, l.identity, entry) {
+		if !VerifyEntrySignature(l.keystore, entry) {
 			fmt.Printf("Warning: Skipping entry with invalid signature: %s\n", entry.Hash)
 			continue
 		}
@@ -173,7 +173,7 @@ func (l *Log) Traverse(startHash string, shouldStop func(*EncodedEntry) bool) ([
 		}
 
 		// Verify the signature before processing
-		if !VerifyEntrySignature(l.keystore, l.identity, *entry) {
+		if !VerifyEntrySignature(l.keystore, *entry) {
 			fmt.Printf("Warning: Skipping entry with invalid signature: %s\n", entry.Hash)
 			continue
 		}
@@ -209,7 +209,7 @@ func (l *Log) JoinEntry(entry *EncodedEntry, processed map[string]bool) error {
 		return fmt.Errorf("entry ID '%s' does not match log ID '%s'", entry.Entry.ID, l.id)
 	}
 
-	if !VerifyEntrySignature(l.keystore, l.identity, *entry) {
+	if !VerifyEntrySignature(l.keystore, *entry) {
 		return fmt.Errorf("invalid signature for entry %s", entry.Hash)
 	}
 

--- a/oplog/log_test.go
+++ b/oplog/log_test.go
@@ -1,162 +1,150 @@
 package oplog
 
 import (
-	"fmt"
-	"orbitdb/go-orbitdb/identities/identitytypes"
-	"orbitdb/go-orbitdb/identities/providers"
-	"sync"
 	"testing"
 
-	"orbitdb/go-orbitdb/keystore"
 	"orbitdb/go-orbitdb/storage"
 )
 
-func createIdentityWithProvider(keyStore *keystore.KeyStore, id string) (*identitytypes.Identity, error) {
-	// Initialize the PublicKeyProvider with the KeyStore
-	provider := providers.NewPublicKeyProvider(keyStore)
+func TestNewLog(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 
-	// Use the provider to create an identity
-	identity, err := provider.CreateIdentity(id)
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create identity using provider: %w", err)
+		t.Fatalf("Failed to create new log: %v", err)
 	}
 
-	return identity, nil
+	if log == nil {
+		t.Fatal("Expected log to be non-nil")
+	}
+
+	if logID != log.id {
+		t.Errorf("Expected log ID to be '%s', got '%s'", logID, log.id)
+	}
+
+	if log.identity != identity {
+		t.Error("Log identity does not match the provided identity")
+	}
+
+	if log.clock.ID != identity.ID || log.clock.Time != 0 {
+		t.Errorf("Expected clock to be initialized with ID '%s' and Time 0, got ID '%s' and Time %d",
+			identity.ID, log.clock.ID, log.clock.Time)
+	}
+}
+
+func TestLog_AppendAndGet(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
+
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
+	if err != nil {
+		t.Fatalf("Failed to create new log: %v", err)
+	}
+
+	payloads := []string{"first entry", "second entry", "third entry"}
+	appendedEntries := make([]*EncodedEntry, 0, len(payloads))
+
+	for _, payload := range payloads {
+		entry, err := log.Append(payload)
+		if err != nil {
+			t.Fatalf("Failed to append entry: %v", err)
+		}
+		appendedEntries = append(appendedEntries, entry)
+	}
+
+	for i, appendedEntry := range appendedEntries {
+		retrievedEntry, err := log.Get(appendedEntry.Hash)
+		if err != nil {
+			t.Fatalf("Failed to get entry: %v", err)
+		}
+		if retrievedEntry.Hash != appendedEntry.Hash {
+			t.Errorf("Retrieved entry hash does not match appended entry hash. Expected %s, got %s",
+				appendedEntry.Hash, retrievedEntry.Hash)
+		}
+		if retrievedEntry.Payload != appendedEntry.Payload {
+			t.Errorf("Retrieved entry payload does not match appended entry payload. Expected %s, got %s",
+				appendedEntry.Payload, retrievedEntry.Payload)
+		}
+		if retrievedEntry.Payload != payloads[i] {
+			t.Errorf("Retrieved entry payload does not match expected payload. Expected %s, got %s",
+				payloads[i], retrievedEntry.Payload)
+		}
+	}
 }
 
 func TestLog_AppendAndRetrieve(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	keyStore := keystore.NewKeyStore(storage)
+	// Step 1: Set up the test keystore and identity
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 
-	// Create identity using PublicKeyProvider
-	identity, err := createIdentityWithProvider(keyStore, "test-identity")
+	// Step 2: Create a new log instance
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
 	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
+		t.Fatalf("Failed to create new log: %v", err)
 	}
 
-	log, err := NewLog("test-log", identity, storage, keyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log: %v", err)
+	// Step 3: Append multiple entries to the log
+	payloads := []string{"first entry", "second entry", "third entry"}
+	appendedEntries := make([]*EncodedEntry, 0, len(payloads))
+
+	for _, payload := range payloads {
+		entry, err := log.Append(payload)
+		if err != nil {
+			t.Fatalf("Failed to append entry: %v", err)
+		}
+		appendedEntries = append(appendedEntries, entry)
 	}
 
-	entry, err := log.Append("Hello, World!")
-	if err != nil {
-		t.Fatalf("Failed to append entry: %v", err)
+	// Step 4: Retrieve each appended entry using the Get method and verify
+	for i, appendedEntry := range appendedEntries {
+		retrievedEntry, err := log.Get(appendedEntry.Hash)
+		if err != nil {
+			t.Fatalf("Failed to get entry: %v", err)
+		}
+		if retrievedEntry.Hash != appendedEntry.Hash {
+			t.Errorf("Retrieved entry hash does not match appended entry hash. Expected %s, got %s", appendedEntry.Hash, retrievedEntry.Hash)
+		}
+		if retrievedEntry.Payload != appendedEntry.Payload {
+			t.Errorf("Retrieved entry payload does not match appended entry payload. Expected %s, got %s", appendedEntry.Payload, retrievedEntry.Payload)
+		}
+		if retrievedEntry.Payload != payloads[i] {
+			t.Errorf("Retrieved entry payload does not match expected payload. Expected %s, got %s", payloads[i], retrievedEntry.Payload)
+		}
 	}
 
-	head, err := log.Head()
-	if err != nil {
-		t.Fatalf("Failed to retrieve log head: %v", err)
-	}
-	if head.Hash != entry.Hash {
-		t.Fatalf("Log head does not match the appended entry")
-	}
-
-	retrieved, err := log.Get(entry.Hash)
-	if err != nil {
-		t.Fatalf("Failed to retrieve entry: %v", err)
-	}
-
-	if retrieved.Payload != "Hello, World!" {
-		t.Errorf("Expected payload 'Hello, World!', got '%s'", retrieved.Payload)
-	}
-}
-
-func TestLog_Clear(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	keyStore := keystore.NewKeyStore(storage)
-
-	// Create identity using PublicKeyProvider
-	identity, err := createIdentityWithProvider(keyStore, "test-identity")
-	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
-	}
-
-	log, err := NewLog("test-log", identity, storage, keyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log: %v", err)
-	}
-
-	_, err = log.Append("Entry 1")
-	if err != nil {
-		t.Fatalf("Failed to append entry: %v", err)
-	}
-
-	if err := log.Clear(); err != nil {
-		t.Fatalf("Failed to clear log: %v", err)
-	}
-
-	if _, err := log.Head(); err == nil {
-		t.Fatalf("Expected error when retrieving head of cleared log")
-	}
-
+	// Step 5: Test the Values method to ensure all entries are correctly stored and ordered
 	entries, err := log.Values()
 	if err != nil {
-		t.Fatalf("Failed to retrieve values after clear: %v", err)
+		t.Fatalf("Failed to get log values: %v", err)
 	}
 
-	if len(entries) != 0 {
-		t.Errorf("Expected 0 entries after clear, got %d", len(entries))
-	}
-}
-
-func TestLog_ConcurrentAppend(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	keyStore := keystore.NewKeyStore(storage)
-
-	// Create identity using PublicKeyProvider
-	identity, err := createIdentityWithProvider(keyStore, "test-identity")
-	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
+	if len(entries) != len(payloads) {
+		t.Errorf("Expected %d entries, got %d", len(payloads), len(entries))
 	}
 
-	log, err := NewLog("test-log", identity, storage, keyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log: %v", err)
-	}
-
-	var wg sync.WaitGroup
-	appendCount := 100
-	wg.Add(appendCount)
-
-	for i := 0; i < appendCount; i++ {
-		go func(i int) {
-			defer wg.Done()
-			_, err := log.Append(string(rune('A' + i%26)))
-			if err != nil {
-				t.Errorf("Failed to append entry: %v", err)
-			}
-		}(i)
-	}
-
-	wg.Wait()
-
-	entries, err := log.Values()
-	if err != nil {
-		t.Fatalf("Failed to retrieve values: %v", err)
-	}
-
-	if len(entries) != appendCount {
-		t.Errorf("Expected %d entries, got %d", appendCount, len(entries))
+	// The entries should be sorted in the order they were appended
+	for i, entry := range entries {
+		if entry.Payload != payloads[i] {
+			t.Errorf("Entry %d payload mismatch: expected '%s', got '%s'", i, payloads[i], entry.Payload)
+		}
 	}
 }
 
-func TestLog_MultipleAppendsAndRetrieval(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	keyStore := keystore.NewKeyStore(storage)
+func TestLog_Values(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 
-	// Create identity using PublicKeyProvider
-	identity, err := createIdentityWithProvider(keyStore, "test-identity")
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
 	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
+		t.Fatalf("Failed to create new log: %v", err)
 	}
 
-	log, err := NewLog("test-log", identity, storage, keyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log: %v", err)
-	}
-
-	payloads := []string{"Entry 1", "Entry 2", "Entry 3"}
+	payloads := []string{"entry1", "entry2", "entry3"}
 	for _, payload := range payloads {
 		_, err := log.Append(payload)
 		if err != nil {
@@ -166,7 +154,7 @@ func TestLog_MultipleAppendsAndRetrieval(t *testing.T) {
 
 	entries, err := log.Values()
 	if err != nil {
-		t.Fatalf("Failed to retrieve entries: %v", err)
+		t.Fatalf("Failed to get log values: %v", err)
 	}
 
 	if len(entries) != len(payloads) {
@@ -175,136 +163,214 @@ func TestLog_MultipleAppendsAndRetrieval(t *testing.T) {
 
 	for i, entry := range entries {
 		if entry.Payload != payloads[i] {
-			t.Errorf("Expected payload '%s', got '%s'", payloads[i], entry.Payload)
+			t.Errorf("Entry %d payload mismatch: expected '%s', got '%s'",
+				i, payloads[i], entry.Payload)
 		}
 	}
 }
 
-func TestLog_WithCustomKeyStore(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	customKeyStore := keystore.NewKeyStore(storage)
+func TestLog_Traverse(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
 
-	// Create identity using PublicKeyProvider
-	identity, err := createIdentityWithProvider(customKeyStore, "custom-identity")
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
 	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
+		t.Fatalf("Failed to create new log: %v", err)
 	}
 
-	log, err := NewLog("test-log", identity, storage, customKeyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log with custom KeyStore: %v", err)
+	payloads := []string{"entry1", "entry2", "entry3", "entry4", "entry5"}
+	for _, payload := range payloads {
+		_, err := log.Append(payload)
+		if err != nil {
+			t.Fatalf("Failed to append entry: %v", err)
+		}
 	}
 
-	entry, err := log.Append("Custom KeyStore Entry")
+	count := 0
+	shouldStop := func(e *EncodedEntry) bool {
+		count++
+		return count >= 3
+	}
+
+	traversedEntries, err := log.Traverse("", shouldStop)
 	if err != nil {
-		t.Fatalf("Failed to append entry with custom KeyStore: %v", err)
+		t.Fatalf("Failed to traverse log: %v", err)
+	}
+
+	if len(traversedEntries) != 3 {
+		t.Errorf("Expected to traverse 3 entries, got %d", len(traversedEntries))
+	}
+
+	for i, entry := range traversedEntries {
+		expectedPayload := payloads[len(payloads)-1-i]
+		if entry.Payload != expectedPayload {
+			t.Errorf("Traversed entry %d payload mismatch: expected '%s', got '%s'",
+				i, expectedPayload, entry.Payload)
+		}
+	}
+}
+
+func TestLog_JoinEntry(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
+
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	// Create a new entry to join
+	clock := NewClock(identity.ID, 1)
+	entry := NewEntry(ks, identity, logID, "joined entry", clock, nil, nil)
+
+	processed := make(map[string]bool)
+	err = log.JoinEntry(&entry, processed)
+	if err != nil {
+		t.Fatalf("Failed to join entry: %v", err)
+	}
+
+	retrievedEntry, err := log.Get(entry.Hash)
+	if err != nil {
+		t.Fatalf("Failed to get entry: %v", err)
+	}
+
+	if retrievedEntry.Hash != entry.Hash {
+		t.Errorf("Joined entry hash does not match. Expected %s, got %s",
+			entry.Hash, retrievedEntry.Hash)
+	}
+	if retrievedEntry.Payload != entry.Payload {
+		t.Errorf("Joined entry payload does not match. Expected '%s', got '%s'",
+			entry.Payload, retrievedEntry.Payload)
+	}
+}
+
+func TestLog_Join(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
+
+	logID := "test-log"
+	entryStorage1 := storage.NewMemoryStorage()
+	log1, err := NewLog(logID, identity, entryStorage1, ks)
+	if err != nil {
+		t.Fatalf("Failed to create log1: %v", err)
+	}
+
+	entryStorage2 := storage.NewMemoryStorage()
+	log2, err := NewLog(logID, identity, entryStorage2, ks)
+	if err != nil {
+		t.Fatalf("Failed to create log2: %v", err)
+	}
+
+	payloads1 := []string{"entry1-log1", "entry2-log1"}
+	for _, payload := range payloads1 {
+		_, err := log1.Append(payload)
+		if err != nil {
+			t.Fatalf("Failed to append to log1: %v", err)
+		}
+	}
+
+	payloads2 := []string{"entry1-log2", "entry2-log2"}
+	for _, payload := range payloads2 {
+		_, err := log2.Append(payload)
+		if err != nil {
+			t.Fatalf("Failed to append to log2: %v", err)
+		}
+	}
+
+	err = log1.Join(log2)
+	if err != nil {
+		t.Fatalf("Failed to join log2 into log1: %v", err)
+	}
+
+	entries, err := log1.Values()
+	if err != nil {
+		t.Fatalf("Failed to get log1 values: %v", err)
+	}
+
+	expectedEntryCount := len(payloads1) + len(payloads2)
+	if len(entries) != expectedEntryCount {
+		t.Errorf("Expected %d entries after join, got %d",
+			expectedEntryCount, len(entries))
+	}
+
+	// Optionally, check that the entries contain the expected payloads
+	payloadSet := make(map[string]bool)
+	for _, payload := range append(payloads1, payloads2...) {
+		payloadSet[payload] = true
+	}
+	for _, entry := range entries {
+		if !payloadSet[entry.Payload] {
+			t.Errorf("Unexpected entry payload: '%s'", entry.Payload)
+		}
+	}
+}
+
+func TestLog_Clear(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
+
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	payloads := []string{"entry1", "entry2", "entry3"}
+	for _, payload := range payloads {
+		_, err := log.Append(payload)
+		if err != nil {
+			t.Fatalf("Failed to append entry: %v", err)
+		}
+	}
+
+	err = log.Clear()
+	if err != nil {
+		t.Fatalf("Failed to clear the log: %v", err)
+	}
+
+	entries, err := log.Values()
+	if err != nil {
+		t.Fatalf("Failed to get log values: %v", err)
+	}
+
+	if len(entries) != 0 {
+		t.Errorf("Expected 0 entries after clear, got %d", len(entries))
+	}
+
+	head, err := log.Head()
+	if err == nil {
+		t.Errorf("Expected head to be nil after clear, but got head with hash %s", head.Hash)
+	}
+}
+
+func TestLog_Head(t *testing.T) {
+	ks, identity := setupTestKeyStoreAndIdentity(t)
+
+	logID := "test-log"
+	entryStorage := storage.NewMemoryStorage()
+	log, err := NewLog(logID, identity, entryStorage, ks)
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	_, err = log.Head()
+	if err == nil {
+		t.Error("Expected error when getting head of empty log, but got none")
+	}
+
+	entry, err := log.Append("first entry")
+	if err != nil {
+		t.Fatalf("Failed to append entry: %v", err)
 	}
 
 	head, err := log.Head()
 	if err != nil {
-		t.Fatalf("Failed to retrieve log head: %v", err)
+		t.Fatalf("Failed to get log head: %v", err)
 	}
+
 	if head.Hash != entry.Hash {
-		t.Fatalf("Log head does not match the appended entry")
-	}
-
-	retrieved, err := log.Get(entry.Hash)
-	if err != nil {
-		t.Fatalf("Failed to retrieve entry: %v", err)
-	}
-
-	if retrieved.Payload != "Custom KeyStore Entry" {
-		t.Errorf("Expected payload 'Custom KeyStore Entry', got '%s'", retrieved.Payload)
-	}
-}
-
-func TestLog_Traversal(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	keyStore := keystore.NewKeyStore(storage)
-
-	// Create identity
-	identity, err := createIdentityWithProvider(keyStore, "test-identity")
-	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
-	}
-
-	log, err := NewLog("test-log", identity, storage, keyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log: %v", err)
-	}
-
-	// Append multiple entries
-	payloads := []string{"Entry 1", "Entry 2", "Entry 3"}
-	var _ *EncodedEntry
-	for _, payload := range payloads {
-		_, err = log.Append(payload)
-		if err != nil {
-			t.Fatalf("Failed to append entry: %v", err)
-		}
-	}
-
-	// Traverse the log starting from the head
-	entries, err := log.Traverse("", nil)
-	if err != nil {
-		t.Fatalf("Failed to traverse log: %v", err)
-	}
-
-	if len(entries) != len(payloads) {
-		t.Errorf("Expected %d entries, got %d", len(payloads), len(entries))
-	}
-
-	// Check if entries match the payloads
-	for i, entry := range entries {
-		if entry.Payload != payloads[len(payloads)-1-i] { // Reverse order because of stack traversal
-			t.Errorf("Expected payload '%s', got '%s'", payloads[len(payloads)-1-i], entry.Payload)
-		}
-	}
-}
-
-func TestLog_TraversalWithStopCondition(t *testing.T) {
-	storage := storage.NewMemoryStorage()
-	keyStore := keystore.NewKeyStore(storage)
-
-	// Create identity
-	identity, err := createIdentityWithProvider(keyStore, "test-identity")
-	if err != nil {
-		t.Fatalf("Failed to create identity: %v", err)
-	}
-
-	log, err := NewLog("test-log", identity, storage, keyStore)
-	if err != nil {
-		t.Fatalf("Failed to create log: %v", err)
-	}
-
-	// Append multiple entries
-	payloads := []string{"Entry 1", "Entry 2", "Entry 3"}
-	var _ *EncodedEntry
-	for _, payload := range payloads {
-		_, err = log.Append(payload)
-		if err != nil {
-			t.Fatalf("Failed to append entry: %v", err)
-		}
-	}
-
-	// Stop traversal after the first entry
-	stopCondition := func(entry *EncodedEntry) bool {
-		return entry.Payload == "Entry 2"
-	}
-
-	entries, err := log.Traverse("", stopCondition)
-	if err != nil {
-		t.Fatalf("Failed to traverse log: %v", err)
-	}
-
-	// Check the result
-	expectedEntries := []string{"Entry 3", "Entry 2"} // In reverse order due to stack traversal
-	if len(entries) != len(expectedEntries) {
-		t.Errorf("Expected %d entries, got %d", len(expectedEntries), len(entries))
-	}
-
-	for i, entry := range entries {
-		if entry.Payload != expectedEntries[i] {
-			t.Errorf("Expected payload '%s', got '%s'", expectedEntries[i], entry.Payload)
-		}
+		t.Errorf("Head hash does not match the last appended entry. Expected %s, got %s",
+			entry.Hash, head.Hash)
 	}
 }


### PR DESCRIPTION
This PR refactors the `log` and `entry` modules and introduces key enhancements:

- Added `Traverse`, `Join`, and `VerifyEntrySignature` in `log.go`.
- Refactored `Encode`, `Decode`, and `IsEqual` in `entry` for clarity and efficiency.
- Updated `Log` struct to use `*identitytypes.Identity`.
- Enhanced `VerifyEntrySignature` to exclude `Identity` and use the entry.
- Improved test coverage across `log` and `entry`.
